### PR TITLE
Load instructions

### DIFF
--- a/src/cpu/decode.rs
+++ b/src/cpu/decode.rs
@@ -17,7 +17,7 @@ impl CPU {
             0x3 => InstParam::Register8Bit(Register8Bit::E),
             0x4 => InstParam::Register8Bit(Register8Bit::H),
             0x5 => InstParam::Register8Bit(Register8Bit::L),
-            0x6 => InstParam::Number8Bit,
+            0x6 => InstParam::Number8Bit(0), //number8bit and 16bit will need to get actual numbers passed right?
             0x7 => InstParam::Register8Bit(Register8Bit::A),
             _ => panic!("Unknown tail: {:X}", tail),
         }

--- a/src/cpu/instructions.rs
+++ b/src/cpu/instructions.rs
@@ -67,8 +67,8 @@ pub enum InstParam {
     Register8Bit(Register8Bit),
     Register16Bit(Register16Bit),
     ConditionCodes(InstructionCondition),
-    Number8Bit,
-    Number16Bit,
+    Number8Bit(u8),
+    Number16Bit(u16),
     Offset,
     Unsigned3Bit,
 }
@@ -86,6 +86,7 @@ pub enum Instructions {
     HALT,
 
     LD(InstParam, InstParam),
+
 
     NOP,
 }

--- a/src/cpu/instructions.rs
+++ b/src/cpu/instructions.rs
@@ -2,6 +2,7 @@ use super::registers::{Register16Bit, Register8Bit};
 
 pub mod arithmetic_and_logic;
 pub mod misc;
+pub mod load;
 
 /// The Flag States after an instruction
 /// Set: The flag is set

--- a/src/cpu/instructions/load.rs
+++ b/src/cpu/instructions/load.rs
@@ -412,5 +412,48 @@ pub fn load_test() {
     cpu.ld_a_hli();
     registers = cpu.get_registry_dump();
     assert_eq!(registers[Register8Bit::A as usize], 8);
+    //11) LDH 
+    cpu.ld_r8_n8(Register8Bit::A, 111);
+    cpu.ldh_n16_a(0xFEFF);
+    cpu.ld_r8_n8(Register8Bit::A, 222);
+    cpu.ldh_n16_a(0xFF00);
+    cpu.ldh_a_n16(0xFEFF);
+    registers = cpu.get_registry_dump();
+    assert_ne!(registers[Register8Bit::A as usize], 111);
+    cpu.ldh_a_n16(0xFF00);
+    registers = cpu.get_registry_dump();
+    assert_eq!(registers[Register8Bit::A as usize], 222);
+    //12) LDI und LDD
+    cpu.ld_r16_n16(Register16Bit::HL,0xFF04);
+    cpu.ld_r8_n8(Register8Bit::A, 121);
+    cpu.ld_hli_a();
+    registers = cpu.get_registry_dump();
+    let register_value = Register16Bit::HL as usize;
+    let high = registers[register_value.clone()] as u16;
+    let low = registers[register_value + 1] as u16;
+    let result = (high << 8) | low;
+    assert_eq!(result, 0xFF05);
 
+    cpu.ld_r8_n8(Register8Bit::A, 131);
+    cpu.ld_hld_a();
+    registers = cpu.get_registry_dump();
+    let register_value = Register16Bit::HL as usize;
+    let high = registers[register_value.clone()] as u16;
+    let low = registers[register_value + 1] as u16;
+    let result = (high << 8) | low;
+    assert_eq!(result, 0xFF04);
+
+    cpu.ld_a_hli();
+    registers = cpu.get_registry_dump();
+    assert_eq!(registers[Register8Bit::A as usize], 121);
+
+    cpu.ld_a_hld();
+    registers = cpu.get_registry_dump();
+    assert_eq!(registers[Register8Bit::A as usize], 131);
+
+    let register_value = Register16Bit::HL as usize;
+    let high = registers[register_value.clone()] as u16;
+    let low = registers[register_value + 1] as u16;
+    let result = (high << 8) | low;
+    assert_eq!(result, 0xFF04);
 }

--- a/src/cpu/instructions/load.rs
+++ b/src/cpu/instructions/load.rs
@@ -180,4 +180,156 @@ impl CPU {
             },
         }
     }
+    /// loads(copies) the value from memory at the address in 16bit-register source into register A
+    /// https://rgbds.gbdev.io/docs/v0.6.1/gbz80.7/#LD_A,_r16_
+    pub fn ld_a_r16 (&mut self, source: Register16Bit)-> InstructionResult {
+        let memory_address = self.get_16bit_register(source);
+        let value = self.memory.read_byte(memory_address);
+
+        self.set_8bit_register(Register8Bit::A, value);
+        InstructionResult {
+            cycles: 2,
+            bytes: 1,
+            condition_codes: ConditionCodes {
+                zero: FlagState::NotAffected,
+                subtract: FlagState::NotAffected,
+                half_carry: FlagState::NotAffected,
+                carry: FlagState::NotAffected,
+            },
+        }
+    }
+    /// loads(copies) the value from memory at the 16bit-address source into register A
+    /// https://rgbds.gbdev.io/docs/v0.6.1/gbz80.7/#LD_A,_n16_
+    pub fn ld_a_n16 (&mut self, source: u16)-> InstructionResult {
+        let value = self.memory.read_byte(source);
+        self.set_8bit_register(Register8Bit::A, value);
+
+        InstructionResult {
+            cycles: 4,
+            bytes: 3,
+            condition_codes: ConditionCodes {
+                zero: FlagState::NotAffected,
+                subtract: FlagState::NotAffected,
+                half_carry: FlagState::NotAffected,
+                carry: FlagState::NotAffected,
+            },
+        }
+    }
+    /// loads(copies) the value from memory at the 16bit-address source into register A if the address is between $FF00 and $FFFF
+    /// https://rgbds.gbdev.io/docs/v0.6.1/gbz80.7/#LDH_A,_n16_
+    pub fn ldh_a_n16 (&mut self, source: u16)-> InstructionResult {
+        if source > 0xFF00u16 && source < 0xFFFFu16 {
+            let value = self.memory.read_byte(source);
+            self.set_8bit_register(Register8Bit::A, value);
+        }
+
+        InstructionResult {
+            cycles: 3,
+            bytes: 2,
+            condition_codes: ConditionCodes {
+                zero: FlagState::NotAffected,
+                subtract: FlagState::NotAffected,
+                half_carry: FlagState::NotAffected,
+                carry: FlagState::NotAffected,
+            },
+        }
+    }
+    /// loads(copies) the value from memory at the 16bit-address 0xFF00 + c into register A. TODO was ist C hier?
+    /// https://rgbds.gbdev.io/docs/v0.6.1/gbz80.7/#LDH_A,_C_
+    pub fn ldh_a_c (&mut self)-> InstructionResult {
+        let source = 0xFF00u16 + self.get_8bit_register(Register8Bit::C) as u16;
+        let value = self.memory.read_byte(source);
+        self.set_8bit_register(Register8Bit::A, value);
+
+        InstructionResult {
+            cycles: 2,
+            bytes: 1,
+            condition_codes: ConditionCodes {
+                zero: FlagState::NotAffected,
+                subtract: FlagState::NotAffected,
+                half_carry: FlagState::NotAffected,
+                carry: FlagState::NotAffected,
+            },
+        }
+    }
+    /// loads(copies) the value in register A into memory at the address in HL and increments HL afterwards
+    /// https://rgbds.gbdev.io/docs/v0.6.1/gbz80.7/#LD__HLI_,A
+    pub fn ld_hli_a (&mut self)-> InstructionResult {
+        let value = self.get_8bit_register(Register8Bit::A);
+        let memory_address = self.get_16bit_register(Register16Bit::HL);
+
+        self.memory.write_byte(memory_address, value);
+        self.set_16bit_register(Register16Bit::HL, memory_address+1u16);
+
+        InstructionResult {
+            cycles: 2,
+            bytes: 1,
+            condition_codes: ConditionCodes {
+                zero: FlagState::NotAffected,
+                subtract: FlagState::NotAffected,
+                half_carry: FlagState::NotAffected,
+                carry: FlagState::NotAffected,
+            },
+        }
+    }
+    /// loads(copies) the value in register A into memory at the address in HL and decrements HL afterwards
+    /// https://rgbds.gbdev.io/docs/v0.6.1/gbz80.7/#LD__HLD_,A
+    pub fn ld_hld_a (&mut self)-> InstructionResult {
+        let value = self.get_8bit_register(Register8Bit::A);
+        let memory_address = self.get_16bit_register(Register16Bit::HL);
+
+        self.memory.write_byte(memory_address, value);
+        self.set_16bit_register(Register16Bit::HL, memory_address-1u16);
+
+        InstructionResult {
+            cycles: 2,
+            bytes: 1,
+            condition_codes: ConditionCodes {
+                zero: FlagState::NotAffected,
+                subtract: FlagState::NotAffected,
+                half_carry: FlagState::NotAffected,
+                carry: FlagState::NotAffected,
+            },
+        }
+    }
+    /// loads(copies) the value in memory at the address in HL into register A and decrements HL afterwards 
+    /// https://rgbds.gbdev.io/docs/v0.6.1/gbz80.7/#LD_A,_HLD_
+    pub fn ld_a_hld (&mut self)-> InstructionResult {
+        let memory_address = self.get_16bit_register(Register16Bit::HL);
+        let value = self.memory.read_byte(memory_address);
+
+        self.set_8bit_register(Register8Bit::A, value);
+        self.set_16bit_register(Register16Bit::HL, memory_address-1u16);
+
+        InstructionResult {
+            cycles: 2,
+            bytes: 1,
+            condition_codes: ConditionCodes {
+                zero: FlagState::NotAffected,
+                subtract: FlagState::NotAffected,
+                half_carry: FlagState::NotAffected,
+                carry: FlagState::NotAffected,
+            },
+        }
+    }
+    /// loads(copies) the value in memory at the address in HL into register A and increments HL afterwards 
+    /// https://rgbds.gbdev.io/docs/v0.6.1/gbz80.7/#LD_A,_HLI_
+    pub fn ld_a_hli (&mut self)-> InstructionResult {
+        let memory_address = self.get_16bit_register(Register16Bit::HL);
+        let value = self.memory.read_byte(memory_address);
+
+        self.set_8bit_register(Register8Bit::A, value);
+        self.set_16bit_register(Register16Bit::HL, memory_address+1u16);
+
+        InstructionResult {
+            cycles: 2,
+            bytes: 1,
+            condition_codes: ConditionCodes {
+                zero: FlagState::NotAffected,
+                subtract: FlagState::NotAffected,
+                half_carry: FlagState::NotAffected,
+                carry: FlagState::NotAffected,
+            },
+        }
+    }
 }

--- a/src/cpu/instructions/load.rs
+++ b/src/cpu/instructions/load.rs
@@ -1,0 +1,183 @@
+use crate::{cpu::{
+    instructions::{ConditionCodes, FlagState, InstructionResult},
+    registers::{Register16Bit, Register8Bit},
+    CPU,
+}, memory};
+
+impl CPU {
+    /// loads(copies) the value of the source 8bit-register into the target 8bit-register
+    /// https://rgbds.gbdev.io/docs/v0.6.1/gbz80.7/#LD_r8,r8
+    pub fn ld_r8_r8(&mut self, target: Register8Bit, source: Register8Bit)-> InstructionResult {
+        let value = self.get_8bit_register(source);
+        self.set_8bit_register(target, value);
+
+        InstructionResult {
+            cycles: 1,
+            bytes: 1,
+            condition_codes: ConditionCodes {
+                zero: FlagState::NotAffected,
+                subtract: FlagState::NotAffected,
+                half_carry: FlagState::NotAffected,
+                carry: FlagState::NotAffected,
+            },
+        }
+    }
+    /// loads(copies) the 8bit-value n8 into the target 8bit-register 
+    /// https://rgbds.gbdev.io/docs/v0.6.1/gbz80.7/#LD_r8,n8
+    pub fn ld_r8_n8(&mut self, target: Register8Bit, value: u8)-> InstructionResult {
+        self.set_8bit_register(target, value);
+
+        InstructionResult {
+            cycles: 2,
+            bytes: 2,
+            condition_codes: ConditionCodes {
+                zero: FlagState::NotAffected,
+                subtract: FlagState::NotAffected,
+                half_carry: FlagState::NotAffected,
+                carry: FlagState::NotAffected,
+            },
+        }
+    }
+    /// loads(copies) the 16bit-value n16 into the target 16bit-register
+    /// https://rgbds.gbdev.io/docs/v0.6.1/gbz80.7/#LD_r16,n16
+    pub fn ld_r16_n16(&mut self, target: Register16Bit, value: u16)-> InstructionResult {
+        self.set_16bit_register(target, value);
+
+        InstructionResult {
+            cycles: 3,
+            bytes: 3,
+            condition_codes: ConditionCodes {
+                zero: FlagState::NotAffected,
+                subtract: FlagState::NotAffected,
+                half_carry: FlagState::NotAffected,
+                carry: FlagState::NotAffected,
+            },
+        }
+    }
+    /// loads(copies) the value of the source 8bit-register into the memory at the byte pointed to by register HL
+    /// https://rgbds.gbdev.io/docs/v0.6.1/gbz80.7/#LD__HL_,r8
+    pub fn ld_hl_r8(&mut self, source: Register8Bit)-> InstructionResult {
+        let value = self.get_8bit_register(source);
+        let memory_address = self.get_16bit_register(Register16Bit::HL);
+        self.memory.write_byte(memory_address, value);
+
+        InstructionResult {
+            cycles: 2,
+            bytes: 1,
+            condition_codes: ConditionCodes {
+                zero: FlagState::NotAffected,
+                subtract: FlagState::NotAffected,
+                half_carry: FlagState::NotAffected,
+                carry: FlagState::NotAffected,
+            },
+        }
+    }
+    /// loads(copies) the 8bit value n8 into the memory at the byte pointed to by register HL
+    /// https://rgbds.gbdev.io/docs/v0.6.1/gbz80.7/#LD__HL_,n8
+    pub fn ld_hl_n8(&mut self, value: u8)-> InstructionResult {
+        let memory_address = self.get_16bit_register(Register16Bit::HL);
+        self.memory.write_byte(memory_address, value);
+
+        InstructionResult {
+            cycles: 3,
+            bytes: 2,
+            condition_codes: ConditionCodes {
+                zero: FlagState::NotAffected,
+                subtract: FlagState::NotAffected,
+                half_carry: FlagState::NotAffected,
+                carry: FlagState::NotAffected,
+            },
+        }
+    }
+    /// loads(copies) the 8bit value at the byte in memory pointed to by register HL into the target 8bit-register
+    /// https://rgbds.gbdev.io/docs/v0.6.1/gbz80.7/#LD_r8,_HL_
+    pub fn ld_r8_hl(&mut self, target: Register8Bit)-> InstructionResult {
+        let memory_address = self.get_16bit_register(Register16Bit::HL);
+        let value = self.memory.read_byte(memory_address);
+
+        self.set_8bit_register(target, value);
+        InstructionResult {
+            cycles: 2,
+            bytes: 1,
+            condition_codes: ConditionCodes {
+                zero: FlagState::NotAffected,
+                subtract: FlagState::NotAffected,
+                half_carry: FlagState::NotAffected,
+                carry: FlagState::NotAffected,
+            },
+        }
+    }
+    /// loads(copies) the value in register A into memory at the address in target 16bit-register
+    /// https://rgbds.gbdev.io/docs/v0.6.1/gbz80.7/#LD__r16_,A
+    pub fn ld_r16_a (&mut self, target: Register16Bit)-> InstructionResult {
+        let value = self.get_8bit_register(Register8Bit::A);
+        let memory_address = self.get_16bit_register(target);
+        self.memory.write_byte(memory_address, value);
+
+        InstructionResult {
+            cycles: 2,
+            bytes: 1,
+            condition_codes: ConditionCodes {
+                zero: FlagState::NotAffected,
+                subtract: FlagState::NotAffected,
+                half_carry: FlagState::NotAffected,
+                carry: FlagState::NotAffected,
+            },
+        }
+    }
+    /// loads(copies) the value in register A into memory at the 16bit-address target
+    /// https://rgbds.gbdev.io/docs/v0.6.1/gbz80.7/#LD__n16_,A
+    pub fn ld_n16_a (&mut self, target: u16)-> InstructionResult {
+        let value = self.get_8bit_register(Register8Bit::A);
+        self.memory.write_byte(target, value);
+
+        InstructionResult {
+            cycles: 4,
+            bytes: 3,
+            condition_codes: ConditionCodes {
+                zero: FlagState::NotAffected,
+                subtract: FlagState::NotAffected,
+                half_carry: FlagState::NotAffected,
+                carry: FlagState::NotAffected,
+            },
+        }
+    }
+    /// loads(copies) the value in register A into memory at the 16bit-address target if the address is between $FF00 and $FFFF
+    /// https://rgbds.gbdev.io/docs/v0.6.1/gbz80.7/#LDH__n16_,A
+    pub fn ldh_n16_a (&mut self, target: u16)-> InstructionResult {
+        if target > 0xFF00u16 && target < 0xFFFFu16 {
+            let value = self.get_8bit_register(Register8Bit::A);
+            self.memory.write_byte(target, value);
+        }
+
+        InstructionResult {
+            cycles: 3,
+            bytes: 2,
+            condition_codes: ConditionCodes {
+                zero: FlagState::NotAffected,
+                subtract: FlagState::NotAffected,
+                half_carry: FlagState::NotAffected,
+                carry: FlagState::NotAffected,
+            },
+        }
+    }
+    /// loads(copies) the value in register A into memory at the address $FF00+C 
+    /// https://rgbds.gbdev.io/docs/v0.6.1/gbz80.7/#LDH__C_,A
+    pub fn ldh_c_a (&mut self)-> InstructionResult {
+        let target = 0xFF00u16 + self.get_8bit_register(Register8Bit::C) as u16;
+        let value = self.get_8bit_register(Register8Bit::A);
+        
+        self.memory.write_byte(target, value);
+
+        InstructionResult {
+            cycles: 2,
+            bytes: 1,
+            condition_codes: ConditionCodes {
+                zero: FlagState::NotAffected,
+                subtract: FlagState::NotAffected,
+                half_carry: FlagState::NotAffected,
+                carry: FlagState::NotAffected,
+            },
+        }
+    }
+}

--- a/src/cpu/instructions/misc.rs
+++ b/src/cpu/instructions/misc.rs
@@ -1,4 +1,7 @@
-use crate::{cpu::CPU, test_helpers::{assert_correct_instruction_decode, assert_correct_instruction_step}};
+use crate::cpu::CPU;
+
+#[cfg(test)]
+use crate::test_helpers::{assert_correct_instruction_decode, assert_correct_instruction_step};
 
 use super::{ConditionCodes, FlagState, InstructionResult, Instructions};
 

--- a/src/cpu/step.rs
+++ b/src/cpu/step.rs
@@ -1,4 +1,4 @@
-use super::{instructions::{InstParam, Instructions}, registers::Register16Bit, CPU};
+use super::{instructions::{InstParam, Instructions}, registers::{Register16Bit, Register8Bit}, CPU};
 
 impl CPU {
     // Gets a 8-bit value from the HL register
@@ -15,8 +15,47 @@ impl CPU {
             Instructions::ADD(param) => {
                 match param {
                     InstParam::Register8Bit(register) => self.add_a_r8(register.clone()),
-                    InstParam::Number8Bit => self.add_a_hl(),
+                    InstParam::Number8Bit(number) => self.add_a_hl(),
                     _ => panic!("ADD with {:?} not implemented", param),
+                }
+            }
+            Instructions::LD(target, source) => {
+                match target {
+                    InstParam::Register8Bit(target_register) => {
+                        if *target_register == Register8Bit::A {
+                            match source {
+                                InstParam::Register16Bit(source_register) => self.ld_a_r16( *source_register),
+                                InstParam::Number16Bit(source_number) => self.ld_a_n16( *source_number),
+                                InstParam::Register8Bit(source_register) => self.ld_r8_r8(*target_register, *source_register),
+                                _ => panic!("Handling of {:?} not implemented", source),
+                            }
+                        } else {
+                            match source {
+                                InstParam::Register8Bit(source_register) => self.ld_r8_r8(*target_register, *source_register),
+                                InstParam::Number8Bit(source_number) => self.ld_r8_n8(*target_register, *source_number),
+                                InstParam::Register16Bit(source_register) => self.ld_r8_hl(*target_register),
+                                _ => panic!("Handling of {:?} not implemented", source),
+                            }
+                        }
+                    },
+                    InstParam::Register16Bit(target_register) => {
+                        if *target_register == Register16Bit::HL{
+                            //TODO what about HLI und HLD?
+                            match source {
+                                InstParam::Register8Bit(source_register) => self.ld_hl_r8(*source_register),
+                                InstParam::Number8Bit(source_number) => self.ld_hl_n8(*source_number),
+                                _ => panic!("Handling of {:?} not implemented", source),
+                            }
+                        } else {
+                            match source {
+                                InstParam::Number16Bit(source_number) => self.ld_r16_n16(*target_register,*source_number),
+                                InstParam::Register8Bit(source_register) => self.ld_r16_a(*target_register),
+                                _ => panic!("Handling of {:?} not implemented", source),
+                            }
+                        }
+                    },
+                    InstParam::Number16Bit(number) => self.ld_n16_a(*number),
+                    _ => panic!("Handling of {:?} not implemented", target),
                 }
             }
             _ => panic!("Handling of {:?} not implemented", self.next_instruction),


### PR DESCRIPTION
Finished the load instruction set with the exception of the LD [C],A and LD A,[C] since we currently aren't sure who C is.
Basic tests for the load instructions are included.
I also added 10 out of 18 load instructions to the step.rs, the other 8 will either need more enum-Instructions entries or another way to pass the information to do a ldh/ldi/ldd instead of a simple load. 